### PR TITLE
feat/page jumbotron

### DIFF
--- a/src/components/Employees.js
+++ b/src/components/Employees.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { graphql, StaticQuery } from "gatsby";
 import { Employee } from "./Employee";
+import PageJumbotron from "./PageJumbotron";
 
 class Employees extends React.Component {
   render() {
@@ -11,6 +12,11 @@ class Employees extends React.Component {
 
     return (
       <div className="columns is-multiline">
+        <PageJumbotron
+          title={"Solution"}
+          image={""}
+          description={"All our solutions can be tailor made for YOUR needs"}
+        />
         {employees &&
           employees.map(({ node: employee }) => (
             <div className="is-parent column is-6" key={employee.id}>

--- a/src/components/Employees.js
+++ b/src/components/Employees.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { graphql, StaticQuery } from "gatsby";
 import { Employee } from "./Employee";
-import PageJumbotron from "./PageJumbotron";
 
 class Employees extends React.Component {
   render() {
@@ -12,11 +11,6 @@ class Employees extends React.Component {
 
     return (
       <div className="columns is-multiline">
-        <PageJumbotron
-          title={"Solution"}
-          image={""}
-          description={"All our solutions can be tailor made for YOUR needs"}
-        />
         {employees &&
           employees.map(({ node: employee }) => (
             <div className="is-parent column is-6" key={employee.id}>

--- a/src/components/PageJumbotron.js
+++ b/src/components/PageJumbotron.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 const PageJumbotron = ({ title, image, description }) => {
-  const inputImage = image ? image : `url('/img/blog-index.jpg')`;
+  const inputImage = image !== "" ? image : `url('/img/blog-index.jpg')`;
   return (
     <div>
       <div

--- a/src/components/PageJumbotron.js
+++ b/src/components/PageJumbotron.js
@@ -2,26 +2,21 @@ import React from "react";
 import PropTypes from "prop-types";
 
 const PageJumbotron = ({ title, image, description }) => {
+  const inputImage = image ? image : `url('/img/blog-index.jpg')`;
   return (
-    <div className="jumbotron-container">
+    <div>
       <div
         className="full-width-image-container-margin-top-0"
         style={{
-          backgroundImage: `url('/img/blog-index.jpg')`
+          backgroundImage: inputImage
         }}
       >
-        <div className="jumbotron-centered-elements">
-          <h1
-            className="has-text-weight-bold is-size-1"
-            style={{
-              color: "white",
-              padding: "1rem"
-            }}
-          >
-            {title}
-          </h1>
-          <hr className="hr-jumbotron" />
-          <h3>{description}</h3>
+        <div className="black-overlay-opacity-50">
+          <div className="jumbotron-centered-elements">
+            <h1 className="h1-page-title">{title.toUpperCase()}</h1>
+            <hr className="hr-jumbotron" />
+            <h3 className="h3-page-subtitle">{description}</h3>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/PageJumbotron.js
+++ b/src/components/PageJumbotron.js
@@ -1,0 +1,35 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const PageJumbotron = ({ title, image, description }) => {
+  return (
+    <div className="container">
+      <div
+        className="full-width-image-container-margin-top-0"
+        style={{
+          backgroundImage: `url('/img/blog-index.jpg')`
+        }}
+      >
+        <h1
+          className="has-text-weight-bold is-size-1"
+          style={{
+            color: "white",
+            padding: "1rem"
+          }}
+        >
+          {title}
+        </h1>
+        <hr className="hr-jumbotron" />
+        <h3>{description}</h3>
+      </div>
+    </div>
+  );
+};
+
+PageJumbotron.propTypes = {
+  title: PropTypes.string,
+  description: PropTypes.string,
+  image: PropTypes.oneOfType([PropTypes.object, PropTypes.string])
+};
+
+export default PageJumbotron;

--- a/src/components/PageJumbotron.js
+++ b/src/components/PageJumbotron.js
@@ -3,24 +3,26 @@ import PropTypes from "prop-types";
 
 const PageJumbotron = ({ title, image, description }) => {
   return (
-    <div className="container">
+    <div className="jumbotron-container">
       <div
         className="full-width-image-container-margin-top-0"
         style={{
           backgroundImage: `url('/img/blog-index.jpg')`
         }}
       >
-        <h1
-          className="has-text-weight-bold is-size-1"
-          style={{
-            color: "white",
-            padding: "1rem"
-          }}
-        >
-          {title}
-        </h1>
-        <hr className="hr-jumbotron" />
-        <h3>{description}</h3>
+        <div className="jumbotron-centered-elements">
+          <h1
+            className="has-text-weight-bold is-size-1"
+            style={{
+              color: "white",
+              padding: "1rem"
+            }}
+          >
+            {title}
+          </h1>
+          <hr className="hr-jumbotron" />
+          <h3>{description}</h3>
+        </div>
       </div>
     </div>
   );

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -40,6 +40,17 @@ nav
     margin-bottom: 1.5rem
     margin-top: 0
 
+.jumbotron-centered-elements
+  display: flex
+  flex-direction: column
+  justify-content: center
+  align-items: center
+  width: 100vw
+  height: 700px
+
+.jumbotron-container
+  margin: 0
+
 // Helper Classes
 .full-width-image-container
   width: 100vw
@@ -56,7 +67,7 @@ nav
 
 .full-width-image
   width: 100vw
-  height: 400px
+  height: 700px
   background-size: cover
   background-position: bottom
   display: flex

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -13,15 +13,17 @@ $primary-invert: $kaldi-red-invert
 $body-color: #333
 $black: #2b2523
 
-
-nav 
+nav
   height: 40px
 
 .navbar .navbar-menu
-  box-shadow:none !important
+  box-shadow: none !important
 
-.navbar 
+.navbar
   background-color: $fjellblue !important
+
+.hr-jumbotron
+  width: 10%
 
 .content .taglist
   list-style: none
@@ -53,30 +55,30 @@ nav
   align-items: center
 
 .full-width-image
-    width: 100vw
-    height: 400px
-    background-size: cover
-    background-position: bottom
-    display: flex
-    justify-content: center
-    align-items: center
+  width: 100vw
+  height: 400px
+  background-size: cover
+  background-position: bottom
+  display: flex
+  justify-content: center
+  align-items: center
 
 .btn
-    display: inline-block
-    padding: 12px 16px 10px
-    font-size: 18px
-    font-size: 1rem
-    line-height: 1.25
-    background-color: #fff
-    border-radius: .25rem
-    text-decoration: none
-    font-weight: 700
-    color: #CC3700
-    text-align: center
-    -webkit-box-shadow: inset 0 0 0 2px #CC3700
-    box-shadow: inset 0 0 0 2px #f40
-    -webkit-transition: all .15s ease
-    transition: all .15s ease
+  display: inline-block
+  padding: 12px 16px 10px
+  font-size: 18px
+  font-size: 1rem
+  line-height: 1.25
+  background-color: #fff
+  border-radius: .25rem
+  text-decoration: none
+  font-weight: 700
+  color: #CC3700
+  text-align: center
+  -webkit-box-shadow: inset 0 0 0 2px #CC3700
+  box-shadow: inset 0 0 0 2px #f40
+  -webkit-transition: all .15s ease
+  transition: all .15s ease
 
 .margin-top-0
   margin-top: 0 !important
@@ -103,7 +105,6 @@ $menu-item-active-background-color:	$kaldi-red-invert
 $menu-list-border-left: 1px solid $kaldi-red-invert
 $menu-label-color: $white-ter
 
-
 .menu-label
   font-size: 1em !important
   text-align: left
@@ -113,38 +114,36 @@ $menu-label-color: $white-ter
 .social
   padding: 2em
 .social a
-    padding: .5em .5em .3em .5em
-    border-radius: 1em
-    background-color: $white-ter
-    margin: .5em
-    width: 1em
-    height: 1em
-    vertical-align: middle
-    display: inline
+  padding: .5em .5em .3em .5em
+  border-radius: 1em
+  background-color: $white-ter
+  margin: .5em
+  width: 1em
+  height: 1em
+  vertical-align: middle
+  display: inline
 
 // blog roll
 .blog-list-item.is-featured
-  background-color: #d6400033;
+  background-color: #d6400033
 .blog-list-item header
-  display: flex;
-  margin-bottom: 1em;
+  display: flex
+  margin-bottom: 1em
 .blog-list-item .featured-thumbnail
-  flex-basis: 35%;
-  margin: 0 1.5em 0 0;
-
+  flex-basis: 35%
+  margin: 0 1.5em 0 0
 
 @import "~bulma"
-
 
 // responsiveness
 +tablet-only
   .blog-list-item .featured-thumbnail
-    flex-basis: 50%;
+    flex-basis: 50%
 
 +mobile
   .blog-list-item header
     display: block
   .blog-list-item .featured-thumbnail
-    text-align: center;
-    max-width: 70%;
-    margin: 0 0 1em;
+    text-align: center
+    max-width: 70%
+    margin: 0 0 1em

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -99,7 +99,7 @@ nav
 
 .index-full-width-image
   width: 100vw
-  height: 700px
+  height: 650px
   object-fit: cover
   &.recycle-active
     animation: .5s ease-in-out both image-fade-out

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -31,7 +31,7 @@ nav
   background-color: $fjellblue !important
 
 .hr-jumbotron
-  width: 10%
+  width: 20%
 
 .content .taglist
   list-style: none
@@ -54,10 +54,19 @@ nav
   justify-content: center
   align-items: center
   width: 100vw
-  height: 700px
+  height: 650px
+  animation: 0.5s ease-in fade-in
 
-.jumbotron-container
-  margin: 0
+.h1-page-title
+  color: white
+  font-size: 70px
+  font-weight: bold
+
+.h3-page-subtitle
+  color: white
+  font-size: 22px
+  max-width: 40%
+  text-align: center
 
 // Helper Classes
 .full-width-image-container
@@ -81,6 +90,9 @@ nav
   display: flex
   justify-content: center
   align-items: flex-end
+
+.black-overlay-opacity-50
+  background: rgba(0,0,0, 0.5)
 
 .index-image-container
   position: relative

--- a/src/pages/product/index.js
+++ b/src/pages/product/index.js
@@ -9,7 +9,7 @@ export default class ProductIndexPage extends React.Component {
       <Layout>
         <PageJumbotron
           title={"Products"}
-          image={""}
+          image={`url('/img/products-grid2.jpg')`}
           description={
             "Our base products are used in all our tailored solutions"
           }

--- a/src/pages/product/index.js
+++ b/src/pages/product/index.js
@@ -1,29 +1,20 @@
 import React from "react";
 import Layout from "../../components/Layout";
 import ProductRoll from "../../components/ProductRoll";
+import PageJumbotron from "../../components/PageJumbotron";
 
 export default class ProductIndexPage extends React.Component {
   render() {
     return (
       <Layout>
-        <div
-          className="full-width-image-container margin-top-0"
-          style={{
-            backgroundImage: `url('/img/blog-index.jpg')`
-          }}
-        >
-          <h1
-            className="has-text-weight-bold is-size-1"
-            style={{
-              boxShadow: "0.5rem 0 0 #002060, -0.5rem 0 0 #002060",
-              backgroundColor: "#002060",
-              color: "white",
-              padding: "1rem"
-            }}
-          >
-            Her kommer det informasjon om produkter
-          </h1>
-        </div>
+        <PageJumbotron
+          title={"Products"}
+          image={""}
+          description={
+            "Our base products are used in all our tailored solutions"
+          }
+        />
+
         <section className="section">
           <div className="container">
             <div className="content">

--- a/src/pages/project/index.js
+++ b/src/pages/project/index.js
@@ -1,30 +1,20 @@
-import React from 'react';
-import Layout from '../../components/Layout';
-import ProjectRoll from '../../components/ProjectRoll';
+import React from "react";
+import Layout from "../../components/Layout";
+import ProjectRoll from "../../components/ProjectRoll";
+import PageJumbotron from "../../components/PageJumbotron";
 
 export default class ProjectIndexPage extends React.Component {
   render() {
     return (
       <Layout>
         <div>
-          <div
-            className="full-width-image-container margin-top-0"
-            style={{
-              backgroundImage: `url('/img/blog-index.jpg')`
-            }}
-          >
-            <h1
-              className="has-text-weight-bold is-size-1"
-              style={{
-                boxShadow: '0.5rem 0 0 #002060, -0.5rem 0 0 #002060',
-                backgroundColor: '#002060',
-                color: 'white',
-                padding: '1rem'
-              }}
-            >
-              Her kommer det informasjon om prosjekter
-            </h1>
-          </div>
+          <PageJumbotron
+            title={"Reference Projects"}
+            image={""}
+            description={
+              "Take a look at some of our previous installments! Other product-specific references can be provided on request."
+            }
+          />
           <section className="section is-medium">
             <div className="container">
               <div className="content">


### PR DESCRIPTION
Closes #18 

Features:
- `PageJumbotron` component takes props `titile`, `image` and `description`
- Does not fetch info from CMS to assign these props as of now
- Some `sass` for jumbotron-use and opacity over images